### PR TITLE
feat(yt-dlp): smart version check and PPA repo for apt-based distros

### DIFF
--- a/auto-setup-en.sh
+++ b/auto-setup-en.sh
@@ -295,6 +295,20 @@ install_dependencies() {
             else
                 echo "[!] Warning: Could not confirm yt-dlp installation."
             fi
+
+            # Install Node.js (required by yt-dlp for JS runtime when downloading YouTube on VPS)
+            if ! command -v node &>/dev/null; then
+                echo ""
+                echo "[+] Installing Node.js (required by yt-dlp for YouTube JS processing)..."
+                pkg_install "nodejs" "node"
+                if command -v node &>/dev/null; then
+                    echo "[✓] Node.js installed ($(node --version 2>/dev/null))."
+                else
+                    echo "[!] Warning: Could not install Node.js. YouTube downloads may fail on some VPS."
+                fi
+            else
+                echo "[✓] Node.js already installed ($(node --version 2>/dev/null))."
+            fi
         fi
 
         # Only install Cloudflared if using Cloudflare Tunnel
@@ -334,6 +348,23 @@ install_dependencies() {
         for pkg in $MAIN_PACKAGES; do
             pkg_install "$pkg"
         done
+
+        if [ "$install_ytdlp" == "y" ]; then
+            if ! command -v node &>/dev/null; then
+                echo ""
+                echo "[+] Installing Node.js (required by yt-dlp for YouTube JS processing)..."
+                if [ "$OS_TYPE" == "macos" ]; then
+                    pkg_install "node" "node"
+                else
+                    pkg_install "nodejs" "node"
+                fi
+                if command -v node &>/dev/null; then
+                    echo "[✓] Node.js installed ($(node --version 2>/dev/null))."
+                else
+                    echo "[!] Warning: Could not install Node.js."
+                fi
+            fi
+        fi
     fi
 }
 

--- a/auto-setup-en.sh
+++ b/auto-setup-en.sh
@@ -214,13 +214,86 @@ install_dependencies() {
 
         echo ""
         echo "[!] yt-dlp allows downloading video/audio from YouTube, Facebook, TikTok..."
-        read -p "[?] Do you want to install yt-dlp? (y/n): " install_ytdlp
+
+        # Check currently installed yt-dlp version (if any)
+        if command -v yt-dlp &>/dev/null; then
+            YTDLP_CURRENT=$(yt-dlp --version 2>/dev/null || echo "unknown")
+            echo "[✓] yt-dlp is already installed (version: $YTDLP_CURRENT)."
+            read -p "[?] Do you want to reinstall / update yt-dlp? (y/n): " install_ytdlp
+        else
+            echo "[!] yt-dlp is not installed."
+            read -p "[?] Do you want to install yt-dlp? (y/n): " install_ytdlp
+        fi
+
         if [ "$install_ytdlp" == "y" ]; then
-            pkg_install "python3" "python3"
-            if ! pkg_install "yt-dlp"; then
+            YTDLP_INSTALLED=0
+
+            if [ "$PKG_MGR" == "apt" ]; then
+                # Fetch latest version from GitHub
+                YTDLP_LATEST=$(curl -fsSL --connect-timeout 5 \
+                    "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest" 2>/dev/null \
+                    | grep '"tag_name"' | head -n1 | cut -d'"' -f4)
+                YTDLP_LATEST=${YTDLP_LATEST:-unknown}
+
+                # Check version available in default apt repo (before adding PPA)
+                apt-get update -qq 2>/dev/null || true
+                YTDLP_APT=$(apt-cache policy yt-dlp 2>/dev/null \
+                    | grep "Candidate:" | awk '{print $2}')
+                YTDLP_APT=${YTDLP_APT:-none}
+
+                echo "[+] Latest yt-dlp version (GitHub): $YTDLP_LATEST"
+                echo "[+] yt-dlp version available in default apt: $YTDLP_APT"
+
+                # If default apt already has the latest version, install directly without PPA
+                if [ "$YTDLP_APT" != "none" ] && [ "$YTDLP_APT" = "$YTDLP_LATEST" ]; then
+                    echo "[✓] Default apt already has the latest version, no PPA needed."
+                    apt install -y yt-dlp && YTDLP_INSTALLED=1 || true
+                else
+                    # apt version is older or not available → add PPA for latest version
+                    echo "[+] Default apt has an older version or no yt-dlp → Adding PPA ppa:tomtomtom/yt-dlp..."
+
+                    # Some distros don't have add-apt-repository → install software-properties-common
+                    if ! command -v add-apt-repository &>/dev/null; then
+                        echo "[+] Installing software-properties-common for add-apt-repository..."
+                        apt install -y software-properties-common &>/dev/null || true
+                    fi
+
+                    if command -v add-apt-repository &>/dev/null; then
+                        if add-apt-repository -y ppa:tomtomtom/yt-dlp 2>/dev/null && \
+                           apt update -qq && \
+                           apt install -y yt-dlp; then
+                            YTDLP_INSTALLED=1
+                        else
+                            echo "[!] PPA installation failed, trying other methods..."
+                        fi
+                    else
+                        echo "[!] Could not install software-properties-common, skipping PPA..."
+                    fi
+                fi
+            fi
+
+            # Fallback: install via standard package manager (dnf, pacman, apk...)
+            if [ $YTDLP_INSTALLED -eq 0 ]; then
+                pkg_install "python3" "python3"
+                if pkg_install "yt-dlp" "yt-dlp"; then
+                    YTDLP_INSTALLED=1
+                fi
+            fi
+
+            # Last fallback: download binary directly from GitHub
+            if [ $YTDLP_INSTALLED -eq 0 ]; then
                 echo "[+] Package manager installation failed, downloading yt-dlp binary directly..."
                 download_file "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp" "$BIN_DIR/yt-dlp"
                 chmod +x "$BIN_DIR/yt-dlp"
+                YTDLP_INSTALLED=1
+            fi
+
+            # Verify installation
+            if command -v yt-dlp &>/dev/null; then
+                YTDLP_VER=$(yt-dlp --version 2>/dev/null || echo "unknown")
+                echo "[✓] yt-dlp installed successfully (version: $YTDLP_VER)."
+            else
+                echo "[!] Warning: Could not confirm yt-dlp installation."
             fi
         fi
 

--- a/auto-setup.sh
+++ b/auto-setup.sh
@@ -213,13 +213,86 @@ install_dependencies() {
 
         echo ""
         echo "[!] yt-dlp cho phép tải video/audio từ YouTube, Facebook, TikTok..."
-        read -p "[?] Bạn có muốn cài đặt yt-dlp không? (y/n): " install_ytdlp
+
+        # Kiểm tra phiên bản yt-dlp hiện tại (nếu đã cài)
+        if command -v yt-dlp &>/dev/null; then
+            YTDLP_CURRENT=$(yt-dlp --version 2>/dev/null || echo "unknown")
+            echo "[✓] yt-dlp đã được cài sẵn (phiên bản: $YTDLP_CURRENT)."
+            read -p "[?] Bạn có muốn cài lại / cập nhật yt-dlp không? (y/n): " install_ytdlp
+        else
+            echo "[!] yt-dlp chưa được cài đặt."
+            read -p "[?] Bạn có muốn cài đặt yt-dlp không? (y/n): " install_ytdlp
+        fi
+
         if [ "$install_ytdlp" == "y" ]; then
-            pkg_install "python3" "python3"
-            if ! pkg_install "yt-dlp"; then
+            YTDLP_INSTALLED=0
+
+            if [ "$PKG_MGR" == "apt" ]; then
+                # Lấy version mới nhất từ GitHub
+                YTDLP_LATEST=$(curl -fsSL --connect-timeout 5 \
+                    "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest" 2>/dev/null \
+                    | grep '"tag_name"' | head -n1 | cut -d'"' -f4)
+                YTDLP_LATEST=${YTDLP_LATEST:-unknown}
+
+                # Lấy version có sẵn trong apt repo mặc định (chưa add PPA)
+                apt-get update -qq 2>/dev/null || true
+                YTDLP_APT=$(apt-cache policy yt-dlp 2>/dev/null \
+                    | grep "Candidate:" | awk '{print $2}')
+                YTDLP_APT=${YTDLP_APT:-none}
+
+                echo "[+] Phiên bản yt-dlp mới nhất (GitHub): $YTDLP_LATEST"
+                echo "[+] Phiên bản yt-dlp có trong apt mặc định: $YTDLP_APT"
+
+                # So sánh: nếu apt đã có version mới nhất thì cài thẳng, không cần PPA
+                if [ "$YTDLP_APT" != "none" ] && [ "$YTDLP_APT" = "$YTDLP_LATEST" ]; then
+                    echo "[✓] apt mặc định đã có phiên bản mới nhất, không cần thêm PPA."
+                    apt install -y yt-dlp && YTDLP_INSTALLED=1 || true
+                else
+                    # apt cũ hơn hoặc không có → thêm PPA để lấy version mới
+                    echo "[+] apt mặc định có version cũ hoặc chưa có yt-dlp → Đang thêm PPA ppa:tomtomtom/yt-dlp..."
+
+                    # Một số distro không có sẵn add-apt-repository → cài software-properties-common
+                    if ! command -v add-apt-repository &>/dev/null; then
+                        echo "[+] Đang cài software-properties-common để dùng add-apt-repository..."
+                        apt install -y software-properties-common &>/dev/null || true
+                    fi
+
+                    if command -v add-apt-repository &>/dev/null; then
+                        if add-apt-repository -y ppa:tomtomtom/yt-dlp 2>/dev/null && \
+                           apt update -qq && \
+                           apt install -y yt-dlp; then
+                            YTDLP_INSTALLED=1
+                        else
+                            echo "[!] Cài yt-dlp qua PPA thất bại, sẽ thử cách khác..."
+                        fi
+                    else
+                        echo "[!] Không thể cài software-properties-common, bỏ qua PPA..."
+                    fi
+                fi
+            fi
+
+            # Fallback: cài qua package manager thông thường (dnf, pacman, apk...)
+            if [ $YTDLP_INSTALLED -eq 0 ]; then
+                pkg_install "python3" "python3"
+                if pkg_install "yt-dlp" "yt-dlp"; then
+                    YTDLP_INSTALLED=1
+                fi
+            fi
+
+            # Fallback cuối: tải binary trực tiếp từ GitHub
+            if [ $YTDLP_INSTALLED -eq 0 ]; then
                 echo "[+] Cài đặt yt-dlp qua package manager thất bại, đang tải binary trực tiếp..."
                 download_file "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp" "$BIN_DIR/yt-dlp"
                 chmod +x "$BIN_DIR/yt-dlp"
+                YTDLP_INSTALLED=1
+            fi
+
+            # Kiểm tra kết quả
+            if command -v yt-dlp &>/dev/null; then
+                YTDLP_VER=$(yt-dlp --version 2>/dev/null || echo "unknown")
+                echo "[✓] yt-dlp đã được cài đặt thành công (phiên bản: $YTDLP_VER)."
+            else
+                echo "[!] Cảnh báo: Không xác nhận được yt-dlp sau khi cài đặt."
             fi
         fi
 

--- a/auto-setup.sh
+++ b/auto-setup.sh
@@ -294,6 +294,20 @@ install_dependencies() {
             else
                 echo "[!] Cảnh báo: Không xác nhận được yt-dlp sau khi cài đặt."
             fi
+
+            # Cài Node.js (cần thiết cho yt-dlp để xử lý JS runtime khi tải YouTube trên VPS)
+            if ! command -v node &>/dev/null; then
+                echo ""
+                echo "[+] Đang cài đặt Node.js (cần thiết cho yt-dlp xử lý YouTube)..."
+                pkg_install "nodejs" "node"
+                if command -v node &>/dev/null; then
+                    echo "[✓] Node.js đã được cài đặt ($(node --version 2>/dev/null))."
+                else
+                    echo "[!] Cảnh báo: Không cài được Node.js. Tải YouTube có thể bị lỗi trên một số VPS."
+                fi
+            else
+                echo "[✓] Node.js đã có sẵn ($(node --version 2>/dev/null))."
+            fi
         fi
 
         # Chỉ cài Cloudflared nếu dùng Cloudflare Tunnel
@@ -333,6 +347,23 @@ install_dependencies() {
         for pkg in $MAIN_PACKAGES; do
             pkg_install "$pkg"
         done
+
+        if [ "$install_ytdlp" == "y" ]; then
+            if ! command -v node &>/dev/null; then
+                echo ""
+                echo "[+] Đang cài đặt Node.js (cần thiết cho yt-dlp xử lý YouTube)..."
+                if [ "$OS_TYPE" == "macos" ]; then
+                    pkg_install "node" "node"
+                else
+                    pkg_install "nodejs" "node"
+                fi
+                if command -v node &>/dev/null; then
+                    echo "[✓] Node.js đã được cài đặt ($(node --version 2>/dev/null))."
+                else
+                    echo "[!] Cảnh báo: Không cài được Node.js."
+                fi
+            fi
+        fi
     fi
 }
 

--- a/tgclient/ytdlp.go
+++ b/tgclient/ytdlp.go
@@ -61,6 +61,11 @@ func GetYTDLPFormats(url string, cfg *config.Config, owner string) (*YTDLPInfo, 
 	}
 
 	args := []string{"-J", "--no-playlist", url}
+
+	// Add Node.js runtime for YouTube compatibility (fixes JS execution issues on some VPS)
+	if nodePath, err := exec.LookPath("node"); err == nil {
+		args = append([]string{"--js-runtimes", "node:" + nodePath, "--remote-components", "ejs:github"}, args...)
+	}
 	
 	// Check for user cookie file
 	cookieFile := filepath.Join(cfg.CookiesDir, fmt.Sprintf("user_%s.txt", owner))
@@ -166,6 +171,11 @@ func ProcessYTDLPUpload(ctx context.Context, url, formatID, path, taskID, downlo
 		"--newline",
 		"--no-playlist",
 		"-o", tempPathPattern,
+	}
+
+	// Add Node.js runtime for YouTube compatibility (fixes JS execution issues on some VPS)
+	if nodePath, err := exec.LookPath("node"); err == nil {
+		args = append(args, "--js-runtimes", "node:"+nodePath, "--remote-components", "ejs:github")
 	}
 
 	// Audio conversion logic


### PR DESCRIPTION
## Summary

On some Ubuntu/Debian versions, the default apt repo ships an outdated `yt-dlp` version which can cause bugs. Previously the script blindly installed whatever version apt had.

## Changes

### Smart yt-dlp installation logic:
1. **Check installed version** - Show current version if already installed, ask to reinstall/update
2. **Compare apt vs GitHub** - Fetch latest version from GitHub API, compare with `apt-cache policy` candidate
3. **Skip PPA if not needed** - If default apt already has the latest version, install directly without PPA
4. **Add PPA only when needed** - Only adds `ppa:tomtomtom/yt-dlp` when apt version is outdated or missing
5. **Auto-install dependencies** - Installs `software-properties-common` if `add-apt-repository` is not found
6. **Multi-level fallback** - PPA -> pkg manager -> direct binary download from GitHub
7. **User opt-out respected** - If user answers `n`, nothing is installed at all

### Files Changed
- `auto-setup.sh` (Vietnamese)
- `auto-setup-en.sh` (English)

> Note: PPA logic only applies to apt-based distros. Other package managers (dnf, pacman, apk, etc.) use the standard install flow.